### PR TITLE
lidar2camera/manual_calib: Fix Eigen vector allocations

### DIFF
--- a/lidar2camera/manual_calib/CMakeLists.txt
+++ b/lidar2camera/manual_calib/CMakeLists.txt
@@ -1,32 +1,27 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(lidar2camera)
-set(CMAKE_CXX_FLAGS "-std=c++11 -g -Wall")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_FLAGS "-g3 -o -Wall")
+set(CMAKE_CXX_STANDARD 17)
 
-find_package(Pangolin REQUIRED)
+find_package(Pangolin 0.8 REQUIRED)
 include_directories(${Pangolin_INCLUDE_DIRS})
 link_directories(${Pangolin_LIBRARY_DIRS})
 
-find_package(PCL REQUIRED)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${OpenCV_LIBRARY_DIRS})
-
+find_package(PCL 1.9 EXACT REQUIRED)
 find_package(Boost REQUIRED system)
 find_package(OpenCV REQUIRED)
+find_package(jsoncpp REQUIRED)
 
+include_directories(${PCL_INCLUDE_DIRS})
 include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${EIGEN_ROOT})
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
+link_directories(${OpenCV_LIBRARY_DIRS})
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 
-file(GLOB_RECURSE PARSER_PATH src/*.cpp)
-add_library(${PROJECT_NAME} STATIC ${PARSER_PATH})
-target_link_libraries(${PROJECT_NAME} libjsoncpp.a ${OpenCV_LIBS} ${Boost_SYSTEM_LIBRARY})
-
 add_executable(run_lidar2camera src/run_lidar2camera.cpp)
-target_link_libraries(run_lidar2camera ${PROJECT_NAME})
-target_link_libraries(run_lidar2camera ${PCL_LIBRARIES})
-target_link_libraries(run_lidar2camera ${Pangolin_LIBRARIES})
+target_link_libraries(run_lidar2camera jsoncpp_lib ${PCL_LIBRARIES} ${Pangolin_LIBRARIES} ${OpenCV_LIBS} ${Boost_SYSTEM_LIBRARY})

--- a/lidar2camera/manual_calib/src/run_lidar2camera.cpp
+++ b/lidar2camera/manual_calib/src/run_lidar2camera.cpp
@@ -37,7 +37,7 @@ static Eigen::Matrix4d orign_calibration_matrix_ = Eigen::Matrix4d::Identity();
 static Eigen::Matrix3d intrinsic_matrix_ = Eigen::Matrix3d::Identity();
 static Eigen::Matrix3d orign_intrinsic_matrix_ = Eigen::Matrix3d::Identity();
 std::vector<float> distortions_;
-std::vector<Eigen::Matrix4d> modification_list_;
+std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Vector4d>> modification_list_(12);
 bool display_mode_ = false;
 bool filter_mode_ = false;
 
@@ -58,7 +58,7 @@ void CalibrationInit(Eigen::Matrix4d json_param) {
   init_cali << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
   calibration_matrix_ = json_param;
   orign_calibration_matrix_ = json_param;
-  modification_list_.reserve(12);
+  modification_list_.resize(12);
   for (int32_t i = 0; i < 12; i++) {
     std::vector<int> transform_flag(6, 0);
     transform_flag[i / 2] = (i % 2) ? (-1) : 1;
@@ -83,7 +83,6 @@ void CalibrationInit(Eigen::Matrix4d json_param) {
 void CalibrationScaleChange() {
   Eigen::Matrix4d init_cali;
   init_cali << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
-  modification_list_.reserve(12);
   for (int32_t i = 0; i < 12; i++) {
     std::vector<int> transform_flag(6, 0);
     transform_flag[i / 2] = (i % 2) ? (-1) : 1;
@@ -244,8 +243,13 @@ int main(int argc, char **argv) {
 
   cout << "Loading data completed!" << endl;
   CalibrationInit(json_param);
+
+  std::cout << __LINE__ << "\n";
+
   Projector projector;
   projector.loadPointCloud(pcd);
+
+  std::cout << __LINE__ << "\n";
 
   // view
   int width = img.cols;


### PR DESCRIPTION
Fixes Eigen allocations in manual calibration. The code was faulty for two reasons:

* Vector not properly initialized. Memory only reserved (`.reserve(12)`), yet init method accessed uninitialized memory -> Core dumped
* Using an [alligned allocator](http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html) to not trigger Eigen runtime assertions